### PR TITLE
Fix #32: Add lecturer validation for attendance to handle twins

### DIFF
--- a/FRAS/Recognize.py
+++ b/FRAS/Recognize.py
@@ -72,6 +72,19 @@ def recognize_attendence():
         cv2.imshow('Attendance', im)
         if (cv2.waitKey(1) == ord('q')):
             break
+    cam.release()
+    cv2.destroyAllWindows()
+
+    print("\n--- Lecturer Verification ---")
+    valid_attendance = attendance.copy()
+    for index, row in attendance.iterrows():
+        confirm = input(f"Confirm attendance for {row['Name']} (Id: {row['Id']})? (y/n): ")
+        if confirm.lower() == 'n':
+            valid_attendance.drop(index, inplace=True)
+            print(f"Attendance for {row['Name']} removed.")
+            
+    attendance = valid_attendance
+
     ts = time.time()
     date = datetime.datetime.fromtimestamp(ts).strftime('%Y-%m-%d')
     timeStamp = datetime.datetime.fromtimestamp(ts).strftime('%H:%M:%S')
@@ -79,7 +92,4 @@ def recognize_attendence():
     fileName = "Attendance"+os.sep+"Attendance_"+date+"_"+Hour+"-"+Minute+"-"+Second+".csv"
     attendance.to_csv(fileName, index=False)
     print("Attendance Successful")
-    cam.release()
-    cv2.destroyAllWindows()
-
 


### PR DESCRIPTION
Resolves #32

### Problem
When the facial recognition system processes twin students, there is a risk of misrecognition leading to incorrect attendance records. The system previously saved all recognized faces to the CSV without any human oversight.

### Solution
This PR introduces a manual validation step to ensure attendance accuracy in special cases like identical twins. After the recognition process ends (when the lecturer stops the video feed by pressing `q`), the system now pauses and prompts the lecturer in the console to individually confirm the attendance of each detected student.

### Changes Made
- Modified `FRAS/Recognize.py` to intercept the attendance list before it gets saved.
- Added a command-line `(y/n)` loop that iterates through all tentatively recognized students.
- Unconfirmed students are dropped from the final attendance dataframe, guaranteeing that the generated CSV only contains verified records.
